### PR TITLE
Fix Cashu plugin for 2.4.0

### DIFF
--- a/BTCPayserver.Plugins.Cashu.Tests/BTCPayserver.Plugins.Cashu.Tests.csproj
+++ b/BTCPayserver.Plugins.Cashu.Tests/BTCPayserver.Plugins.Cashu.Tests.csproj
@@ -3,20 +3,9 @@
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <OutputType>exe</OutputType>
+    <NoWarn>$(NoWarn);xunit1051</NoWarn>
   </PropertyGroup>
-
-  <ItemGroup>
-    <PackageReference Include="BTCPayServer.Lightning.All" Version="1.6.14" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.4" />
-    <PackageReference Include="Microsoft.Playwright" Version="1.58.0" />
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
-    <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Plugin\BTCPayServer.Plugins.Cashu\BTCPayServer.Plugins.Cashu.csproj" />

--- a/BTCPayserver.Plugins.Cashu.Tests/Integration/CashuLightningClientTests.cs
+++ b/BTCPayserver.Plugins.Cashu.Tests/Integration/CashuLightningClientTests.cs
@@ -1,12 +1,10 @@
 using BTCPayServer.Lightning;
-using BTCPayServer.Plugins.Cashu.CashuAbstractions;
 using BTCPayServer.Plugins.Cashu.Data.Models;
 using BTCPayServer.Plugins.Cashu.Lightning;
 using BTCPayserver.Plugins.Cashu.Tests.Unit;
 using BTCPayServer.Tests;
 using NBitcoin;
 using Xunit;
-using Xunit.Abstractions;
 using Mnemonic = DotNut.NBitcoin.BIP39.Mnemonic;
 
 namespace BTCPayserver.Plugins.Cashu.Tests.Integration.E2E;
@@ -17,9 +15,9 @@ public class CashuLightningClientTests(ITestOutputHelper helper) : IAsyncLifetim
 {
     private MintListener? _listener;
 
-    public Task InitializeAsync() => Task.CompletedTask;
+    public ValueTask InitializeAsync() => ValueTask.CompletedTask;
 
-    public async Task DisposeAsync()
+    public async ValueTask DisposeAsync()
     {
         if (_listener is not null)
         {

--- a/BTCPayserver.Plugins.Cashu.Tests/Integration/E2E/CashuLightningSetupTests.cs
+++ b/BTCPayserver.Plugins.Cashu.Tests/Integration/E2E/CashuLightningSetupTests.cs
@@ -1,7 +1,6 @@
 using System.Text.RegularExpressions;
 using BTCPayServer.Tests;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace BTCPayserver.Plugins.Cashu.Tests.Integration.E2E;
 

--- a/BTCPayserver.Plugins.Cashu.Tests/Integration/E2E/CashuOnboardingTests.cs
+++ b/BTCPayserver.Plugins.Cashu.Tests/Integration/E2E/CashuOnboardingTests.cs
@@ -2,7 +2,6 @@ using System.Text.RegularExpressions;
 using BTCPayServer.Tests;
 using NBitcoin;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace BTCPayserver.Plugins.Cashu.Tests.Integration.E2E;
 

--- a/BTCPayserver.Plugins.Cashu.Tests/Integration/E2E/CashuPaymentTests.cs
+++ b/BTCPayserver.Plugins.Cashu.Tests/Integration/E2E/CashuPaymentTests.cs
@@ -3,7 +3,6 @@ using BTCPayServer.Tests;
 
 using NBitcoin;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace BTCPayserver.Plugins.Cashu.Tests.Integration.E2E;
 

--- a/BTCPayserver.Plugins.Cashu.Tests/Integration/E2E/CashuWalletTests.cs
+++ b/BTCPayserver.Plugins.Cashu.Tests/Integration/E2E/CashuWalletTests.cs
@@ -2,7 +2,6 @@ using System.Text.RegularExpressions;
 using BTCPayServer.Tests;
 using NBitcoin;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace BTCPayserver.Plugins.Cashu.Tests.Integration.E2E;
 

--- a/BTCPayserver.Plugins.Cashu.Tests/Integration/E2E/FailedTransactionsApiTests.cs
+++ b/BTCPayserver.Plugins.Cashu.Tests/Integration/E2E/FailedTransactionsApiTests.cs
@@ -1,12 +1,10 @@
 using System.Net;
 using System.Text.Json;
-using BTCPayServer.Abstractions.Constants;
 using BTCPayServer.Client;
 using BTCPayServer.Plugins.Cashu.Data;
 using BTCPayServer.Plugins.Cashu.Data.Models;
 using BTCPayServer.Tests;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace BTCPayserver.Plugins.Cashu.Tests.Integration.E2E;
 

--- a/BTCPayserver.Plugins.Cashu.Tests/Integration/E2E/GreenfieldApiTests.cs
+++ b/BTCPayserver.Plugins.Cashu.Tests/Integration/E2E/GreenfieldApiTests.cs
@@ -5,7 +5,6 @@ using BTCPayServer.Client;
 using BTCPayServer.Tests;
 using NBitcoin;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace BTCPayserver.Plugins.Cashu.Tests.Integration.E2E;
 

--- a/BTCPayserver.Plugins.Cashu.Tests/Integration/MintFixture.cs
+++ b/BTCPayserver.Plugins.Cashu.Tests/Integration/MintFixture.cs
@@ -11,7 +11,7 @@ public class MintFixture : IAsyncLifetime
     public string NutshellMintUrl { get; } =
         Environment.GetEnvironmentVariable("TEST_NUTSHELL_MINT_URL") ?? "http://localhost:3339";
 
-    public async Task InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
         await WaitForMintAsync(CdkMintUrl, "CDK");
         await WaitForMintAsync(NutshellMintUrl, "Nutshell");
@@ -45,7 +45,7 @@ public class MintFixture : IAsyncLifetime
         throw new TimeoutException($"{name} mint at {mintUrl} not ready after {timeoutSeconds}s");
     }
 
-    public Task DisposeAsync() => Task.CompletedTask;
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
 }
 
 [CollectionDefinition("Integration")]

--- a/BTCPayserver.Plugins.Cashu.Tests/Unit/CashuListenerTests.cs
+++ b/BTCPayserver.Plugins.Cashu.Tests/Unit/CashuListenerTests.cs
@@ -1,7 +1,6 @@
 using BTCPayServer.Lightning;
 using BTCPayServer.Plugins.Cashu.Lightning;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace BTCPayserver.Plugins.Cashu.Tests.Unit;
 

--- a/BTCPayserver.Plugins.Cashu.Tests/Unit/FailedTransactionsPollerTests.cs
+++ b/BTCPayserver.Plugins.Cashu.Tests/Unit/FailedTransactionsPollerTests.cs
@@ -2,7 +2,6 @@ using BTCPayServer.Plugins.Cashu.Data;
 using BTCPayServer.Plugins.Cashu.Data.Models;
 using Microsoft.EntityFrameworkCore;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace BTCPayserver.Plugins.Cashu.Tests.Unit;
 

--- a/BTCPayserver.Plugins.Cashu.Tests/Unit/MintListenerTests.cs
+++ b/BTCPayserver.Plugins.Cashu.Tests/Unit/MintListenerTests.cs
@@ -4,7 +4,6 @@ using BTCPayServer.Plugins.Cashu.Data.enums;
 using DotNut;
 using Microsoft.EntityFrameworkCore;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace BTCPayserver.Plugins.Cashu.Tests.Unit;
 

--- a/BTCPayserver.Plugins.Cashu.Tests/Unit/TestDbFactory.cs
+++ b/BTCPayserver.Plugins.Cashu.Tests/Unit/TestDbFactory.cs
@@ -6,7 +6,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
-using Xunit.Abstractions;
+using Xunit;
 
 namespace BTCPayserver.Plugins.Cashu.Tests.Unit;
 
@@ -26,22 +26,13 @@ public class TestDbFactory : CashuDbContextFactory
     {
         DbContextOptions<CashuDbContext> opts;
         var pgConnStr = Environment.GetEnvironmentVariable("TESTS_POSTGRES");
-        if (pgConnStr != null)
+        var builder = new Npgsql.NpgsqlConnectionStringBuilder(pgConnStr)
         {
-            var builder = new Npgsql.NpgsqlConnectionStringBuilder(pgConnStr)
-            {
-                Database = $"cashu_test_{Guid.NewGuid():N}",
-            };
-            opts = new DbContextOptionsBuilder<CashuDbContext>()
-                .UseNpgsql(builder.ConnectionString)
-                .Options;
-        }
-        else
-        {
-            opts = new DbContextOptionsBuilder<CashuDbContext>()
-                .UseInMemoryDatabase(Guid.NewGuid().ToString())
-                .Options;
-        }
+            Database = $"cashu_test_{Guid.NewGuid():N}",
+        };
+        opts = new DbContextOptionsBuilder<CashuDbContext>()
+            .UseNpgsql(builder.ConnectionString)
+            .Options;
 
         using var ctx = new CashuDbContext(opts);
         ctx.Database.EnsureCreated();

--- a/Plugin/BTCPayServer.Plugins.Cashu/BTCPayServer.Plugins.Cashu.csproj
+++ b/Plugin/BTCPayServer.Plugins.Cashu/BTCPayServer.Plugins.Cashu.csproj
@@ -43,8 +43,6 @@
     <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="5.3.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.3.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.4" />
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.0" />
   </ItemGroup>
 
   <ItemGroup>
@@ -65,7 +63,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="BTCPayServer.Lightning.Common" Version="1.5.2" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
   </ItemGroup>
 </Project>

--- a/Plugin/BTCPayServer.Plugins.Cashu/CashuPlugin.cs
+++ b/Plugin/BTCPayServer.Plugins.Cashu/CashuPlugin.cs
@@ -19,7 +19,7 @@ public class CashuPlugin : BaseBTCPayServerPlugin
     public const string PluginNavKey = nameof(CashuPlugin) + "Nav";
     public override IBTCPayServerPlugin.PluginDependency[] Dependencies { get; } =
         {
-            new() { Identifier = nameof(BTCPayServer), Condition = ">=2.3.7" },
+            new() { Identifier = nameof(BTCPayServer), Condition = ">=2.4.0" },
         };
 
     internal static readonly PaymentMethodId CashuPmid = new("CASHU");

--- a/Plugin/BTCPayServer.Plugins.Cashu/Views/Cashu/Onboarding/ConfirmMnemonic.cshtml
+++ b/Plugin/BTCPayServer.Plugins.Cashu/Views/Cashu/Onboarding/ConfirmMnemonic.cshtml
@@ -1,7 +1,7 @@
 @using BTCPayServer
 @model BTCPayServer.Plugins.Cashu.ViewModels.ConfirmMnemonicViewModel
 @{
-    Layout = "Views/UIStores/_LayoutWalletSetup";
+    Layout = "Plugins/Wallets/Views/UIStoreOnChainWallets/_LayoutWalletSetup";
     ViewData["Title"] = "Your recovery phrase";
 }
 

--- a/Plugin/BTCPayServer.Plugins.Cashu/Views/Cashu/Onboarding/GettingStarted.cshtml
+++ b/Plugin/BTCPayServer.Plugins.Cashu/Views/Cashu/Onboarding/GettingStarted.cshtml
@@ -1,6 +1,6 @@
 @model BTCPayServer.Plugins.Cashu.ViewModels.GettingStartedViewModel;
 @{
-    Layout = "Views/UIStores/_LayoutWalletSetup";
+    Layout = "Plugins/Wallets/Views/UIStoreOnChainWallets/_LayoutWalletSetup";
 }
 
 

--- a/Plugin/BTCPayServer.Plugins.Cashu/Views/Cashu/Onboarding/RestoreFromMnemonic.cshtml
+++ b/Plugin/BTCPayServer.Plugins.Cashu/Views/Cashu/Onboarding/RestoreFromMnemonic.cshtml
@@ -1,7 +1,7 @@
 @using BTCPayServer
 @model BTCPayServer.Plugins.Cashu.ViewModels.WalletRestoreViewModel
 @{
-    Layout = "Views/UIStores/_LayoutWalletSetup";
+    Layout = "Plugins/Wallets/Views/UIStoreOnChainWallets/_LayoutWalletSetup";
     ViewData["Title"] = "Restore your Cashu wallet";
     var words = Model?.Words ?? Array.Empty<string>();
 }


### PR DESCRIPTION
- Removes a number of unnecessary references that added maintenance burden.                                                                                                                                                       
- Removes the Entity Framework in-memory provider. It can be kept if desired, but I strongly recommend testing against the real database, since the in-memory provider behaves very                                               
       differently.                                                                                                                                                                                                                    
- The main breaking change is the path to `_LayoutWalletSetup`.  